### PR TITLE
Fix handling for parameters and uncrustify code to keep readability

### DIFF
--- a/src/configfsisomanager.cpp
+++ b/src/configfsisomanager.cpp
@@ -109,6 +109,45 @@ void mount_iso(char *iso_path, char *cdrom, char *ro)
   set_udc(udc, gadgetRoot);
 }
 
+void umount_iso()
+{
+  char *gadgetRoot = get_gadget_root();
+
+  if (gadgetRoot == nullptr)
+  {
+    printf("No active gadget found\n");
+    return;
+  }
+  char *configRoot      = get_config_root();
+  char *udc             = get_udc();
+  char *functionRoot    = strjin(gadgetRoot, (char *)"/functions");
+  char *massStorageRoot = strjin(functionRoot, (char *)"/mass_storage.0");
+  char *lunRoot         = strjin(massStorageRoot, (char *)"/lun.0");
+
+  char *stallFile = strjin(massStorageRoot, (char *)"/stall");
+  char *udcFile   = strjin(gadgetRoot, (char *)"/UDC");
+  char *lunFile   = strjin(lunRoot, (char *)"/file");
+  char *lunCdRom  = strjin(lunRoot, (char *)"/cdrom");
+  char *lunRo     = strjin(lunRoot, (char *)"/ro");
+
+  set_udc((char *)"", gadgetRoot);
+
+  if (!isdir(massStorageRoot))
+  {
+    mkdir(massStorageRoot, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  }
+
+  if (!isdir(strjin(configRoot, (char *)"/mass_storage.0")))
+  {
+    symlink(massStorageRoot, strjin(configRoot, (char *)"/mass_storage.0"));
+  }
+  sysfs_write(lunFile,  (char *)"");
+  sysfs_write(lunCdRom, (char *)"0");
+  sysfs_write(lunRo,    (char *)"0");
+
+  set_udc(udc, gadgetRoot);
+}
+
 void set_udc(char *udc, char *gadget)
 {
   char *udcFile = strjin(gadget, (char *)"/UDC");

--- a/src/configfsisomanager.cpp
+++ b/src/configfsisomanager.cpp
@@ -111,41 +111,8 @@ void mount_iso(char *iso_path, char *cdrom, char *ro)
 
 void umount_iso()
 {
-  char *gadgetRoot = get_gadget_root();
-
-  if (gadgetRoot == nullptr)
-  {
-    printf("No active gadget found\n");
-    return;
-  }
-  char *configRoot      = get_config_root();
-  char *udc             = get_udc();
-  char *functionRoot    = strjin(gadgetRoot, (char *)"/functions");
-  char *massStorageRoot = strjin(functionRoot, (char *)"/mass_storage.0");
-  char *lunRoot         = strjin(massStorageRoot, (char *)"/lun.0");
-
-  char *stallFile = strjin(massStorageRoot, (char *)"/stall");
-  char *udcFile   = strjin(gadgetRoot, (char *)"/UDC");
-  char *lunFile   = strjin(lunRoot, (char *)"/file");
-  char *lunCdRom  = strjin(lunRoot, (char *)"/cdrom");
-  char *lunRo     = strjin(lunRoot, (char *)"/ro");
-
-  set_udc((char *)"", gadgetRoot);
-
-  if (!isdir(massStorageRoot))
-  {
-    mkdir(massStorageRoot, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-  }
-
-  if (!isdir(strjin(configRoot, (char *)"/mass_storage.0")))
-  {
-    symlink(massStorageRoot, strjin(configRoot, (char *)"/mass_storage.0"));
-  }
-  sysfs_write(lunFile,  (char *)"");
-  sysfs_write(lunCdRom, (char *)"0");
-  sysfs_write(lunRo,    (char *)"0");
-
-  set_udc(udc, gadgetRoot);
+  char *empty = (char *)"";
+  mount_iso(empty, empty, empty);
 }
 
 void set_udc(char *udc, char *gadget)

--- a/src/configfsisomanager.cpp
+++ b/src/configfsisomanager.cpp
@@ -11,109 +11,120 @@
 
 bool supported()
 {
-	return fs_mount_point((char*)"configfs") != nullptr;
+  return fs_mount_point((char *)"configfs") != nullptr;
 }
 
-char *get_gadget_root()
+char* get_gadget_root()
 {
-	char *configFsRoot = fs_mount_point((char*)"configfs");
-	char *usbGadgetRoot = strjin(configFsRoot, (char*)"/usb_gadget/"); 
-	char *gadgetRoot = nullptr;
+  char *configFsRoot  = fs_mount_point((char *)"configfs");
+  char *usbGadgetRoot = strjin(configFsRoot, (char *)"/usb_gadget/");
+  char *gadgetRoot    = nullptr;
 
-	struct dirent *entry = nullptr;
-	DIR *dp = nullptr;
-	dp = opendir(usbGadgetRoot);
-	if (dp != nullptr)
-		while ((entry = readdir(dp)))
-		{
-			if (entry->d_name[0] != '.')
-			{
-				char *gadget = strjin(usbGadgetRoot, entry->d_name);
-				if (sysfs_read(strjin(gadget, (char*)"/UDC")) != nullptr)
-				{
-					gadgetRoot = gadget;
-					break;
-				}
-			}
-		}
-	return gadgetRoot;
+  struct dirent *entry = nullptr;
+  DIR *dp              = nullptr;
+
+  dp = opendir(usbGadgetRoot);
+
+  if (dp != nullptr)
+    while ((entry = readdir(dp)))
+    {
+      if (entry->d_name[0] != '.')
+      {
+        char *gadget = strjin(usbGadgetRoot, entry->d_name);
+
+        if (sysfs_read(strjin(gadget, (char *)"/UDC")) != nullptr)
+        {
+          gadgetRoot = gadget;
+          break;
+        }
+      }
+    }
+  return gadgetRoot;
 }
 
-char *get_config_root()
+char* get_config_root()
 {
-	char *gadgetRoot = get_gadget_root();
-	if (gadgetRoot == nullptr)
-	{
-		return nullptr;
-	}
-	char *usbConfigRoot = strjin(gadgetRoot, (char*)"/configs/");
-	char *configRoot = nullptr;
+  char *gadgetRoot = get_gadget_root();
 
-	struct dirent *entry = nullptr;
-	DIR *dp = nullptr;
-	dp = opendir(usbConfigRoot);
-	if (dp != nullptr)
-		while ((entry = readdir(dp)))
-		{
-			if (entry->d_name[0] != '.')
-			{
-				configRoot = strjin(usbConfigRoot, entry->d_name);
-				break;
-			}
-		}
-	return configRoot;
+  if (gadgetRoot == nullptr)
+  {
+    return nullptr;
+  }
+  char *usbConfigRoot = strjin(gadgetRoot, (char *)"/configs/");
+  char *configRoot    = nullptr;
+
+  struct dirent *entry = nullptr;
+  DIR *dp              = nullptr;
+
+  dp = opendir(usbConfigRoot);
+
+  if (dp != nullptr)
+    while ((entry = readdir(dp)))
+    {
+      if (entry->d_name[0] != '.')
+      {
+        configRoot = strjin(usbConfigRoot, entry->d_name);
+        break;
+      }
+    }
+  return configRoot;
 }
 
 void mount_iso(char *iso_path, char *cdrom, char *ro)
 {
-	char *gadgetRoot = get_gadget_root();
-	if (gadgetRoot == nullptr)
-	{
-		printf("No active gadget found\n");
-		return;
-	}
-	char *configRoot = get_config_root();
-	char *udc = get_udc();
-	char *functionRoot = strjin(gadgetRoot, (char*)"/functions");
-	char *massStorageRoot = strjin(functionRoot, (char*)"/mass_storage.0");
-	char *lunRoot = strjin(massStorageRoot, (char*)"/lun.0");
-	
-	char *stallFile = strjin(massStorageRoot, (char*)"/stall");
-	char *udcFile = strjin(gadgetRoot, (char*)"/UDC");
-	char *lunFile = strjin(lunRoot, (char*)"/file");
-	char *lunCdRom = strjin(lunRoot, (char*)"/cdrom");
-	char *lunRo = strjin(lunRoot, (char*)"/ro");
+  char *gadgetRoot = get_gadget_root();
 
-	set_udc((char*)"", gadgetRoot);
-	
-	if (!isdir(massStorageRoot))
-	{
-		mkdir(massStorageRoot, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
-	}
-	if (!isdir(strjin(configRoot, (char*)"/mass_storage.0")))
-	{
-		symlink(massStorageRoot, strjin(configRoot, (char*)"/mass_storage.0"));
-	}
-	sysfs_write(lunFile, iso_path);
-	sysfs_write(lunCdRom, cdrom);
-	sysfs_write(lunRo, ro);
+  if (gadgetRoot == nullptr)
+  {
+    printf("No active gadget found\n");
+    return;
+  }
+  char *configRoot      = get_config_root();
+  char *udc             = get_udc();
+  char *functionRoot    = strjin(gadgetRoot, (char *)"/functions");
+  char *massStorageRoot = strjin(functionRoot, (char *)"/mass_storage.0");
+  char *lunRoot         = strjin(massStorageRoot, (char *)"/lun.0");
 
-	set_udc(udc, gadgetRoot);
+  char *stallFile = strjin(massStorageRoot, (char *)"/stall");
+  char *udcFile   = strjin(gadgetRoot, (char *)"/UDC");
+  char *lunFile   = strjin(lunRoot, (char *)"/file");
+  char *lunCdRom  = strjin(lunRoot, (char *)"/cdrom");
+  char *lunRo     = strjin(lunRoot, (char *)"/ro");
+
+  set_udc((char *)"", gadgetRoot);
+
+  if (!isdir(massStorageRoot))
+  {
+    mkdir(massStorageRoot, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  }
+
+  if (!isdir(strjin(configRoot, (char *)"/mass_storage.0")))
+  {
+    symlink(massStorageRoot, strjin(configRoot, (char *)"/mass_storage.0"));
+  }
+  sysfs_write(lunFile,  iso_path);
+  sysfs_write(lunCdRom, cdrom);
+  sysfs_write(lunRo,    ro);
+
+  set_udc(udc, gadgetRoot);
 }
 
 void set_udc(char *udc, char *gadget)
 {
-	char *udcFile = strjin(gadget, (char*)"/UDC");
-	sysfs_write(udcFile, udc);
+  char *udcFile = strjin(gadget, (char *)"/UDC");
+
+  sysfs_write(udcFile, udc);
 }
 
-char *get_udc()
+char* get_udc()
 {
-	char *gadget_root = get_gadget_root();
-	if (gadget_root == nullptr)
-	{
-		return nullptr;
-	}
-	char *udcFile = strjin(gadget_root, (char*)"/UDC");
-	return sysfs_read(udcFile);
+  char *gadget_root = get_gadget_root();
+
+  if (gadget_root == nullptr)
+  {
+    return nullptr;
+  }
+  char *udcFile = strjin(gadget_root, (char *)"/UDC");
+
+  return sysfs_read(udcFile);
 }

--- a/src/include/configfsisomanager.h
+++ b/src/include/configfsisomanager.h
@@ -1,12 +1,16 @@
 #ifndef CONFIGFSISOMANAGER_H
 #define CONFIGFSISOMANAGER_H
 
-bool supported();
-char *get_gadget_root();
-char *get_config_root();
+bool  supported();
+char* get_gadget_root();
+char* get_config_root();
 
-void mount_iso(char *iso_path, char *cdrom, char *ro);
-void set_udc(char *udc, char *gadget);
-char *get_udc();
+void  mount_iso(char *iso_path,
+                char *cdrom,
+                char *ro);
+void  umount_iso();
+void  set_udc(char *udc,
+              char *gadget);
+char* get_udc();
 
-#endif
+#endif // ifndef CONFIGFSISOMANAGER_H

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -1,11 +1,12 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-char *fs_mount_point(char *filesystem_type);
-char *strjin(char *w1, char *w2);
-bool isdir(char *path);
-char *sysfs_read(char *path);
-void sysfs_write(char *path, char *content);
+char* fs_mount_point(char *filesystem_type);
+char* strjin(char *w1,
+             char *w2);
+bool  isdir(char *path);
+char* sysfs_read(char *path);
+void  sysfs_write(char *path,
+                  char *content);
 
-#endif
-
+#endif // ifndef UTIL_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,55 +3,59 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char* argv[]){
-		char *iso_target = argv[1];
-		char *cdrom = (char*)"0";
-		char *ro = (char*)"1";
-		for (int i = 1; i < argc; i++)
-		{
-			if (strcmp(argv[i], "-rw") == 0)
-			{
-				ro = (char*)"0";
-			}
-			else if (strcmp(argv[i], "-cdrom") == 0)
-			{
-				cdrom = (char*)"1";
-			}
-			else
-			{
-				iso_target = argv[i];
-			}
-		}
+int main(int argc, char *argv[])
+{
+  char *iso_target = argv[1];
+  char *cdrom      = (char *)"0";
+  char *ro         = (char *)"1";
 
-		if (argc == 1)
-		{
-			printf("Usage:\n");
-			printf("cdrom [FILE]... [OPTION]...\n");
-			printf("Mounts the given FILE as a bootable device using configfs.\n");
-			printf("Run without any arguments to unmount any mounted files and display this help message.\n\n");
+  for (int i = 1; i < argc; i++)
+  {
+    if (strcmp(argv[i], "-rw") == 0)
+    {
+      ro = (char *)"0";
+    }
+    else if (strcmp(argv[i], "-cdrom") == 0)
+    {
+      cdrom = (char *)"1";
+    }
+    else
+    {
+      iso_target = argv[i];
+    }
+  }
 
-			printf("Optional arguments:\n");
-			printf("-rw\t Mounts the file in read write mode.\n");
-			printf("-cdrom\t Mounts the file as a cdrom.\n\n");
-			printf("UMOUNT:\n");
-		}
-		else
-		{
-			printf("MOUNT:\n");
-		}
+  if (argc == 1)
+  {
+    printf("Usage:\n");
+    printf("cdrom [FILE]... [OPTION]...\n");
+    printf("Mounts the given FILE as a bootable device using configfs.\n");
+    printf(
+      "Run without any arguments to unmount any mounted files and display this help message.\n\n");
 
-	if (!supported())
-	{
-		printf("Device does not support configfs usb gadget\n");
-		return 1;
-	}
-	if (getuid() != 0)
-	{
-		printf("Permission denied\n");
-		return 1;
-	}
+    printf("Optional arguments:\n");
+    printf("-rw\t Mounts the file in read write mode.\n");
+    printf("-cdrom\t Mounts the file as a cdrom.\n\n");
+    printf("UMOUNT:\n");
+  }
+  else
+  {
+    printf("MOUNT:\n");
+  }
 
-	mount_iso(iso_target, cdrom, ro);
+  if (!supported())
+  {
+    printf("Device does not support configfs usb gadget\n");
+    return 1;
+  }
 
-	return 0;
+  if (getuid() != 0)
+  {
+    printf("Permission denied\n");
+    return 1;
+  }
+
+  mount_iso(iso_target, cdrom, ro);
+
+  return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,6 @@ int main(int argc, char* argv[]){
 		char *iso_target = argv[1];
 		char *cdrom = (char*)"0";
 		char *ro = (char*)"1";
-		
 		for (int i = 1; i < argc; i++)
 		{
 			if (strcmp(argv[i], "-rw") == 0)
@@ -50,19 +49,6 @@ int main(int argc, char* argv[]){
 	{
 		printf("Permission denied\n");
 		return 1;
-	}
-	if (argc == 1)
-	{
-		iso_target = (char*)"";
-	}
-
-	if (argc > 2)
-	{
-		cdrom = argv[2];
-	}
-	if (argc > 3)
-	{
-		ro = argv[3];
 	}
 
 	mount_iso(iso_target, cdrom, ro);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,14 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  mount_iso(iso_target, cdrom, ro);
+  if (argc > 1)
+  {
+    mount_iso(iso_target, cdrom, ro);
+  }
+  else
+  {
+    umount_iso();
+  }
 
   return 0;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,7 +1,7 @@
-#include <fcntl.h>   
-#include <mntent.h>  
-#include <stdio.h>   
-#include <string.h>  
+#include <fcntl.h>
+#include <mntent.h>
+#include <stdio.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fstream>
@@ -11,74 +11,82 @@
 #include <cstdio>
 #include <dirent.h>
 
-char *fs_mount_point(char *filesystem_type) {
-	struct mntent *ent;
-	FILE *mounts;
-	char *mount_point = nullptr;
+char* fs_mount_point(char *filesystem_type)
+{
+  struct mntent *ent;
+  FILE *mounts;
+  char *mount_point = nullptr;
 
-	mounts = setmntent("/proc/mounts", "r");
-	while (nullptr != (ent = getmntent(mounts))) {
-		if (strcmp(ent->mnt_fsname, filesystem_type) == 0)
-		{
-			mount_point = ent->mnt_dir;
-			break;
-		}
-	}
+  mounts = setmntent("/proc/mounts", "r");
 
-	// Alternate search location on Android
-	if (mount_point == nullptr)
-	{
-		const char *alt_usb_gadget = "/config/usb_gadget";
-		DIR *dir = opendir(alt_usb_gadget);
-		if (dir)
-		{
-			mount_point = (char*)"/config";
-		}
-	}
-	return mount_point;
+  while (nullptr != (ent = getmntent(mounts)))
+  {
+    if (strcmp(ent->mnt_fsname, filesystem_type) == 0)
+    {
+      mount_point = ent->mnt_dir;
+      break;
+    }
+  }
+
+  // Alternate search location on Android
+  if (mount_point == nullptr)
+  {
+    const char *alt_usb_gadget = "/config/usb_gadget";
+    DIR *dir                   = opendir(alt_usb_gadget);
+
+    if (dir)
+    {
+      mount_point = (char *)"/config";
+    }
+  }
+  return mount_point;
 }
 
-char *strjin(char *w1, char *w2)
+char* strjin(char *w1, char *w2)
 {
-	char *s = new char[strlen(w1)+strlen(w2)+1];
-	strcpy(s, w1);
-	strcat(s, w2);
-	return s;
+  char *s = new char[strlen(w1) + strlen(w2) + 1];
+
+  strcpy(s, w1);
+  strcat(s, w2);
+  return s;
 }
 
 bool isdir(char *path)
 {
-	struct stat sb;
-	if (stat(path, &sb) == 0)
-		return true;
-	else
-		return false;
+  struct stat sb;
+
+  if (stat(path, &sb) == 0)
+    return true;
+  else
+    return false;
 }
 
 void sysfs_write(char *path, char *content)
 {
-	printf("Write: %s -> %s\n", content, path);
-	std::ofstream sysfsFile(path);
-	sysfsFile << content << std::endl;
-	sysfsFile.close();
+  printf("Write: %s -> %s\n", content, path);
+  std::ofstream sysfsFile(path);
+  sysfsFile << content << std::endl;
+  sysfsFile.close();
 }
 
-char *sysfs_read(char *path)
+char* sysfs_read(char *path)
 {
-	std::string value;
-	std::ifstream sysfsFile(path);
-	if (!sysfsFile.is_open())
-	{
-		return nullptr;
-	}
-	sysfsFile >> value;
-	sysfsFile.close();
-	if (value.empty())
-	{
-		return nullptr;
-	}
-	char *result = new char[value.length() + 1];
-	strcpy(result, value.c_str());
-	return result;
-	
+  std::string   value;
+  std::ifstream sysfsFile(path);
+
+  if (!sysfsFile.is_open())
+  {
+    return nullptr;
+  }
+  sysfsFile >> value;
+  sysfsFile.close();
+
+  if (value.empty())
+  {
+    return nullptr;
+  }
+  char *result = new char[value.length() + 1];
+
+  strcpy(result, value.c_str());
+  return result;
 }


### PR DESCRIPTION
1. Double (triple?) handling of argv leads to bad results (what you input isn't what you're getting)
2. Code can be re-formatted to improve readability (uncrustify is a good tool! using config from [here](https://gist.github.com/HybridRbt/bfcb99f64d8abee25ccabac66e472bc6))
3. No-args run says unmount, so it should do unmount. Not sure about writing parameters, but entering empty ones work. Feel free to improve that.